### PR TITLE
Fix URL template formatting bug

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -234,9 +234,10 @@ def _get_search_urls_for_editor(editor):
                             url_template = predefined_sites[category_name][site_name]
                             # Format the URL with the main field content
                             try:
-                                search_url = url_template.format(main_field_content)
+                                placeholders = url_template.count("{}")
+                                search_url = url_template.format(*([main_field_content] * placeholders))
                                 search_urls.append((site_name, search_url))
-                            except:
+                            except Exception:
                                 # Handle URL formatting errors
                                 pass
     

--- a/browser.py
+++ b/browser.py
@@ -242,7 +242,8 @@ class BrowserWidget(QWidget):
                     for site_name, is_enabled in sites_config.items():
                         if is_enabled and site_name in PREDEFINED_SEARCH_SITES[category_name]:
                             url_template = PREDEFINED_SEARCH_SITES[category_name][site_name]
-                            search_url = url_template.format(search_content_encoded)
+                            placeholders = url_template.count("{}")
+                            search_url = url_template.format(*([search_content_encoded] * placeholders))
                             search_urls.append((f"{site_name} - {field_name}", search_url))
         
         # Clear existing tabs if any and open search tabs


### PR DESCRIPTION
## Summary
- handle search site URL templates with multiple placeholders in `__init__.py`
- handle multiple placeholders in `browser.py`

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6842dd883ef48330a60ae6ddd49dcada