### PR TITLE
Update config path retrieval

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,8 +42,9 @@ PREDEFINED_SEARCH_SITES = {
 }
 
 def get_config_path():
-    """Get the path to the config file."""
-    return os.path.join(mw.pm.addonFolder(), "config.json")
+    """Return the path to the addon's configuration file."""
+    addon_dir = mw.addonManager.addonFolder(__name__)
+    return os.path.join(addon_dir, "config.json")
 
 def get_default_config():
     """Get default configuration."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = tests/test_*.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os
+collect_ignore = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '__init__.py'))]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+
+
+# create a dummy 'aqt' module before importing config
+aqt_dummy = types.ModuleType("aqt")
+
+class DummyMenuBar:
+    def insertMenu(self, *a, **k):
+        pass
+
+class DummyMenuHelp:
+    def menuAction(self):
+        return None
+
+mw_dummy = types.SimpleNamespace(
+    addonManager=None,
+    app=types.SimpleNamespace(keyboardModifiers=lambda: 0),
+    form=types.SimpleNamespace(
+        menubar=DummyMenuBar(),
+        menuHelp=DummyMenuHelp()
+    )
+)
+
+class DummyQt(types.SimpleNamespace):
+    def __getattr__(self, item):
+        return type(item, (), {})
+
+aqt_dummy.mw = mw_dummy
+aqt_dummy.qt = DummyQt()
+aqt_dummy.utils = types.SimpleNamespace(tooltip=lambda *a, **k: None)
+aqt_dummy.gui_hooks = types.SimpleNamespace(editor_did_init_buttons=[], editor_did_init=[], browser_will_show=[])
+
+sys.modules['aqt'] = aqt_dummy
+sys.modules['aqt.qt'] = aqt_dummy.qt
+sys.modules['aqt.utils'] = aqt_dummy.utils
+sys.modules['aqt.gui_hooks'] = aqt_dummy.gui_hooks
+
+import importlib.util
+
+config_path = os.path.join(os.path.dirname(__file__), '..', 'config.py')
+spec = importlib.util.spec_from_file_location('config', config_path)
+config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config)
+
+class DummyAddonManager:
+    def __init__(self):
+        self.called_with = None
+    def addonFolder(self, name):
+        self.called_with = name
+        return '/addon/path'
+
+class DummyMw:
+    def __init__(self, addon_manager):
+        self.addonManager = addon_manager
+
+
+def test_get_config_path(monkeypatch):
+    manager = DummyAddonManager()
+    dummy_mw = DummyMw(manager)
+    monkeypatch.setattr(config, 'mw', dummy_mw)
+    path = config.get_config_path()
+    assert manager.called_with == config.__name__
+    assert path == os.path.join('/addon/path', 'config.json')


### PR DESCRIPTION
## Summary
- retrieve addon directory via `addonManager.addonFolder` in `config.py`
- add pytest config and ignore addon package during collection
- implement tests for config path

## Testing
- `pytest tests/test_config.py -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_6842e43d84cc8330aacf4f9872d221b6