### PR TITLE
Clean up addon and add basic config tests

### DIFF
--- a/settings_action = QAction(_Add Dialog We
+++ b/settings_action = QAction(_Add Dialog We
@@ -1,3 +1,0 @@
-settings_action = QAction("Add Dialog Web Browser", mw)
-settings_action.triggered.connect(show_settings)
-mw.form.menuTools.addAction(settings_action)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,99 @@
 import os
+import sys
+import types
+import importlib
+import pathlib
+import pytest
+
 collect_ignore = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '__init__.py'))]
+
+
+class _DummySignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+
+class _DummyAction:
+    def __init__(self, *args, **kwargs):
+        self.triggered = _DummySignal()
+
+
+class _DummyMenu:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def addAction(self, *args, **kwargs):
+        pass
+
+
+class _DummyMenuBar:
+    def insertMenu(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def dummy_aqt(tmp_path):
+    """Provide a minimal stub of the aqt module required for imports."""
+    qt = types.SimpleNamespace(
+        QWidget=object,
+        QVBoxLayout=object,
+        QShortcut=object,
+        QKeySequence=object,
+        QAction=_DummyAction,
+        QObject=object,
+        QEvent=types.SimpleNamespace(Type=types.SimpleNamespace(KeyPress=0, Close=1, Paint=2, ShortcutOverride=3)),
+        QMenu=_DummyMenu,
+        QSplitter=object,
+        Qt=types.SimpleNamespace(
+            ShortcutContext=types.SimpleNamespace(WidgetWithChildrenShortcut=1),
+            AlignmentFlag=types.SimpleNamespace(AlignLeft=0),
+            TextElideMode=types.SimpleNamespace(ElideRight=0),
+            KeyboardModifier=types.SimpleNamespace(MetaModifier=1, ControlModifier=2),
+            Key=types.SimpleNamespace(Key_W=1),
+        ),
+        QDockWidget=object,
+        QSizePolicy=object,
+        QUrl=str,
+    )
+
+    utils = types.SimpleNamespace(tooltip=lambda *a, **k: None)
+
+    gui_hooks = types.SimpleNamespace(
+        editor_did_init_buttons=[],
+        editor_did_init=[],
+        browser_will_show=[],
+    )
+
+    mw = types.SimpleNamespace(
+        app=types.SimpleNamespace(keyboardModifiers=lambda: 0),
+        form=types.SimpleNamespace(
+            menuHelp=types.SimpleNamespace(menuAction=lambda: None),
+            menubar=_DummyMenuBar(),
+        ),
+        progress=types.SimpleNamespace(timer=lambda *a, **k: None),
+        addonManager=types.SimpleNamespace(addonFolder=lambda name: str(tmp_path)),
+    )
+
+    aqt_module = types.SimpleNamespace(mw=mw, gui_hooks=gui_hooks, qt=qt, utils=utils)
+    return aqt_module
+
+
+@pytest.fixture
+def load_module(monkeypatch, dummy_aqt):
+    """Helper to import project modules with the dummy aqt available."""
+    monkeypatch.setitem(sys.modules, "aqt", dummy_aqt)
+    monkeypatch.setitem(sys.modules, "aqt.qt", dummy_aqt.qt)
+    monkeypatch.setitem(sys.modules, "aqt.utils", dummy_aqt.utils)
+    monkeypatch.setitem(sys.modules, "aqt.gui_hooks", dummy_aqt.gui_hooks)
+
+    def _loader(name):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        sys.path.insert(0, str(root))
+        try:
+            module = importlib.import_module(name)
+            importlib.reload(module)
+            return module
+        finally:
+            sys.path.pop(0)
+
+    return _loader

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,37 @@
-import os
-import sys
+import json
 import types
+import pytest
+
+
+def test_get_default_config_keys(load_module):
+    config = load_module("config")
+    cfg = config.get_default_config()
+    expected_keys = {
+        "note_type",
+        "main_field",
+        "refresh_shortcut",
+        "configurable_fields",
+        "field_search_configs",
+    }
+    assert set(cfg.keys()) == expected_keys
+
+
+def test_get_config_no_file(load_module, tmp_path):
+    config = load_module("config")
+    # aqt.mw.addonManager.addonFolder was set to tmp_path by fixture
+    cfg = config.get_config()
+    assert cfg == config.get_default_config()
+
+
+def test_save_and_get_config_roundtrip(load_module, tmp_path):
+    config = load_module("config")
+    sample = {
+        "note_type": "Basic",
+        "main_field": "Front",
+        "refresh_shortcut": "Ctrl+X",
+        "configurable_fields": {"Basic": ["Front"]},
+        "field_search_configs": {"Basic": {"Front": {}}},
+    }
+    assert config.save_config(sample)
+    loaded = config.get_config()
+    assert loaded == sample


### PR DESCRIPTION
## Summary
- remove duplicate settings action file
- stub out `aqt` for tests
- add tests covering configuration read/write logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ebfb94d083309005690ba66a94ca