### PR TITLE
Handle new addon path API

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,20 @@ PREDEFINED_SEARCH_SITES = {
 
 def get_config_path():
     """Return the path to the addon's configuration file."""
-    addon_dir = mw.addonManager.addonFolder(__name__)
+    mgr = mw.addonManager
+
+    if hasattr(mgr, "addonFolder"):
+        addon_dir = mgr.addonFolder(__name__)
+    elif hasattr(mgr, "addon_meta"):
+        addon_dir = mgr.addon_meta(__name__).path
+    elif hasattr(mgr, "addon_path"):
+        addon_dir = mgr.addon_path(__name__)
+    else:
+        addon_base = getattr(mgr, "addon_base", None)
+        if addon_base is None:
+            raise AttributeError("Cannot determine addon path")
+        addon_dir = os.path.join(addon_base, __name__)
+
     return os.path.join(addon_dir, "config.json")
 
 def get_default_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,13 @@ def dummy_aqt(tmp_path):
         browser_will_show=[],
     )
 
+    addon_manager = types.SimpleNamespace(
+        addonFolder=lambda name: str(tmp_path),
+        addon_meta=lambda name: types.SimpleNamespace(path=str(tmp_path)),
+        addon_path=lambda name: str(tmp_path),
+        addon_base=str(tmp_path),
+    )
+
     mw = types.SimpleNamespace(
         app=types.SimpleNamespace(keyboardModifiers=lambda: 0),
         form=types.SimpleNamespace(
@@ -71,7 +78,7 @@ def dummy_aqt(tmp_path):
             menubar=_DummyMenuBar(),
         ),
         progress=types.SimpleNamespace(timer=lambda *a, **k: None),
-        addonManager=types.SimpleNamespace(addonFolder=lambda name: str(tmp_path)),
+        addonManager=addon_manager,
     )
 
     aqt_module = types.SimpleNamespace(mw=mw, gui_hooks=gui_hooks, qt=qt, utils=utils)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ def test_get_default_config_keys(load_module):
 
 def test_get_config_no_file(load_module, tmp_path):
     config = load_module("config")
-    # aqt.mw.addonManager.addonFolder was set to tmp_path by fixture
+    # addon path attributes were set to tmp_path by fixture
     cfg = config.get_config()
     assert cfg == config.get_default_config()
 


### PR DESCRIPTION
## Summary
- resolve addon folder using new Anki APIs when available
- mock addon path APIs in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f1ced350833098e3fd065f169278